### PR TITLE
Feature/get issue details

### DIFF
--- a/src/github/README.md
+++ b/src/github/README.md
@@ -180,6 +180,14 @@ MCP Server for the GitHub API, enabling file operations, repository management, 
      - `sha` (optional string): branch name
    - Returns: List of commits
 
+17. `get_issue`
+   - Gets the contents of an issue within a repository
+   - Inputs:
+     - `owner` (string): Repository owner
+     - `repo` (string): Repository name
+     - `issue_number` (number): Issue number to retrieve
+   - Returns: Github Issue object & details
+
 ## Search Query Syntax
 
 ### Code Search

--- a/src/github/schemas.ts
+++ b/src/github/schemas.ts
@@ -677,6 +677,12 @@ export const IssueCommentSchema = z.object({
   body: z.string()
 });
 
+export const GetIssueSchema = z.object({
+  owner: z.string().describe("Repository owner (username or organization)"),
+  repo: z.string().describe("Repository name"),
+  issue_number: z.number().describe("Issue number")
+});
+
 // Export types
 export type GitHubAuthor = z.infer<typeof GitHubAuthorSchema>;
 export type GitHubFork = z.infer<typeof GitHubForkSchema>;


### PR DESCRIPTION
Adds the `get_issue` functionality to github-server.

## Description

## Server Details
- Server: **github**
- Changes to: tools

## Motivation and Context
Existing functionality would allow the list of issues to be pulled as an array, however failed to get specific issue data to reference. Claude being able to review Issue Data is important in order to best understand current-state of issues or problems that might be project-managed through an issue.

## How Has This Been Tested?
I have tested this locally both on a Private repo as well as a public repo to access Issue Data. Claud was able to contextualize the Issue and summarize the details.

## Breaking Changes
This should require no updates to users.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

